### PR TITLE
Fix redis configuration

### DIFF
--- a/src/main/kotlin/com/hostiflix/config/RedisConfig.kt
+++ b/src/main/kotlin/com/hostiflix/config/RedisConfig.kt
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.connection.jedis.JedisConnectionFactory
-
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 
 @Configuration
 class RedisConfig {
@@ -18,10 +18,8 @@ class RedisConfig {
 
     @Bean
     fun jedisConnectionFactory(): JedisConnectionFactory {
-        val jedisConFactory = JedisConnectionFactory()
-        hostname
-        port
-        return jedisConFactory
+        val redisStandaloneConfiguration = RedisStandaloneConfiguration(hostname, port.toInt())
+        return JedisConnectionFactory(redisStandaloneConfiguration)
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   profiles:
     active: development
   datasource:
-    url: jdbc:postgresql:hostiflix;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:postgresql:hostiflix
     username: postgres
     password: password
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
# What?

Make Redis hostname and port configurable through Spring `application.yml` and env vars.

# Why?

`hostname` and `port` were not used in `RedisConfig`