### PR TITLE
Fix json deserialization to Kotlin dataclass

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,9 @@ spring:
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults: false
 spring.jpa.database-platform: org.hibernate.dialect.PostgreSQL9Dialect
 
+spring.jackson.serialization.write_dates_as_timestamps: false
+spring.jackson.default-property-inclusion: non_null
+
 jedisConFactory:
   hostname: localhost
   port: 6379

--- a/src/test/kotlin/com/hostiflix/JsonObjectMapperTest.kt
+++ b/src/test/kotlin/com/hostiflix/JsonObjectMapperTest.kt
@@ -1,18 +1,17 @@
 package com.hostiflix
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hostiflix.config.JsonConfig
+import com.hostiflix.dto.GithubCustomerDto
 import com.hostiflix.support.MockData
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
-import org.springframework.test.context.ContextConfiguration
+import org.springframework.boot.test.autoconfigure.json.JsonTest
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 
 @RunWith(SpringJUnit4ClassRunner::class)
-@ContextConfiguration(classes = [JsonConfig::class, JacksonAutoConfiguration::class])
+@JsonTest
 class JsonObjectMapperTest {
 
     @Autowired
@@ -40,5 +39,19 @@ class JsonObjectMapperTest {
 
         /* Then */
         assertThat(jsonString).isEqualTo("{\"id\":\"1\",\"name\":\"name_1\",\"repository\":\"repository_1\",\"projectType\":\"NODEJS\",\"branches\":[{\"id\":\"1\",\"name\":\"name_1\",\"subDomain\":\"subdomain_1\",\"jobs\":[{\"id\":\"j1\",\"status\":\"BUILD_SCHEDULED\",\"createdAt\":\"2019-04-01T00:00:00Z\"},{\"id\":\"j2\",\"status\":\"BUILD_SCHEDULED\",\"createdAt\":\"2019-04-01T00:00:00Z\"}]},{\"id\":\"2\",\"name\":\"name_2\",\"subDomain\":\"subdomain_2\",\"jobs\":[{\"id\":\"j1\",\"status\":\"BUILD_SCHEDULED\",\"createdAt\":\"2019-04-01T00:00:00Z\"},{\"id\":\"j2\",\"status\":\"BUILD_SCHEDULED\",\"createdAt\":\"2019-04-01T00:00:00Z\"}]}]}")
+    }
+
+    @Test
+    fun `should serialize and deserialize Kotlin data class`() {
+        /* Given */
+        val githubCustomer = MockData.githubCustomerDto("g1")
+
+        /* When */
+        val jsonString = objectMapper.writeValueAsString(githubCustomer)
+        val deserialized = objectMapper.readValue(jsonString, GithubCustomerDto::class.java)
+
+        /* Then */
+        assertThat(jsonString).isEqualTo("{\"id\":\"testId\",\"name\":\"name_g1\",\"login\":\"login_g1\"}")
+        assertThat(deserialized).isEqualToComparingFieldByFieldRecursively(githubCustomer)
     }
 }

--- a/src/test/kotlin/com/hostiflix/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/hostiflix/controller/AuthenticationControllerTest.kt
@@ -1,6 +1,7 @@
 package com.hostiflix.controller
 
 import com.hostiflix.service.AuthenticationService
+import com.hostiflix.support.JsonConfig
 import com.nhaarman.mockito_kotlin.given
 import org.hamcrest.Matchers.`is`
 import org.junit.Before
@@ -10,7 +11,9 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
@@ -19,6 +22,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 
 @RunWith(MockitoJUnitRunner::class)
+@ContextConfiguration(classes = [JsonConfig::class, JacksonAutoConfiguration::class])
 @WebMvcTest
 class AuthenticationControllerTest {
 

--- a/src/test/kotlin/com/hostiflix/controller/CustomerControllerTest.kt
+++ b/src/test/kotlin/com/hostiflix/controller/CustomerControllerTest.kt
@@ -1,9 +1,9 @@
 package com.hostiflix.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hostiflix.config.JsonConfig
 import com.hostiflix.entity.Customer
 import com.hostiflix.service.CustomerService
+import com.hostiflix.support.JsonConfig
 import com.hostiflix.support.MockData
 import com.nhaarman.mockito_kotlin.given
 import org.hamcrest.Matchers.`is`

--- a/src/test/kotlin/com/hostiflix/controller/ProjectControllerTest.kt
+++ b/src/test/kotlin/com/hostiflix/controller/ProjectControllerTest.kt
@@ -1,9 +1,9 @@
 package com.hostiflix.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.hostiflix.config.JsonConfig
 import com.hostiflix.entity.Project
 import com.hostiflix.service.ProjectService
+import com.hostiflix.support.JsonConfig
 import com.hostiflix.support.MockData
 import com.nhaarman.mockito_kotlin.*
 import org.assertj.core.api.Assertions.assertThat

--- a/src/test/kotlin/com/hostiflix/support/JsonConfig.kt
+++ b/src/test/kotlin/com/hostiflix/support/JsonConfig.kt
@@ -1,4 +1,4 @@
-package com.hostiflix.config
+package com.hostiflix.support
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.MapperFeature


### PR DESCRIPTION
# What?

Fetching an access-token from Github was not working because there was a problem with the JSON deserialization to Kotlin data classes.

# Why?

`JsonConfig` configuration bean was causing issues with Kotlin data classes, so I added `com.fasterxml.jackson.module:jackson-module-kotlin` to fix it.
This module resulted in another issue where `@JsonManagedReference` and `@JsonBackReference` were not deserialized correctly.

# How?

- removed `JsonConfig` and using `application.yml` for jackson configuration now
- using `@JsonTest` now to test JsonConfiguration
- using dedicated JsonConfig for serializing test JSON's