### PR TITLE
Feat add endpoint to update job status

### DIFF
--- a/src/main/kotlin/com/hostiflix/controller/JobController.kt
+++ b/src/main/kotlin/com/hostiflix/controller/JobController.kt
@@ -1,0 +1,29 @@
+package com.hostiflix.controller
+
+import com.hostiflix.entity.JobStatus
+import com.hostiflix.service.JobService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/jobs")
+class JobController (
+    private val jobService: JobService
+) {
+
+    @PutMapping("/{id}/status/{status}")
+    fun updateJobStatus(
+        @PathVariable
+        id: String,
+        @PathVariable
+        status: JobStatus
+    ): ResponseEntity<*> {
+        if (jobService.updateJobStatusById(id, status) == null) {
+            return ResponseEntity.notFound().build<Any>()
+        }
+        return ResponseEntity.noContent().build<Any>();
+    }
+}

--- a/src/main/kotlin/com/hostiflix/entity/Job.kt
+++ b/src/main/kotlin/com/hostiflix/entity/Job.kt
@@ -12,7 +12,7 @@ class Job (
     @GenericGenerator(name = "system-uuid", strategy = "uuid2")
     var id: String? = null,
 
-    val status: JobStatus,
+    var status: JobStatus,
 
     @Column(nullable = false, updatable = false)
     var createdAt: Instant? = null,

--- a/src/main/kotlin/com/hostiflix/repository/JobRepository.kt
+++ b/src/main/kotlin/com/hostiflix/repository/JobRepository.kt
@@ -1,0 +1,8 @@
+package com.hostiflix.repository
+
+import com.hostiflix.entity.Job
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface JobRepository: CrudRepository<Job, String>

--- a/src/main/kotlin/com/hostiflix/service/JobService.kt
+++ b/src/main/kotlin/com/hostiflix/service/JobService.kt
@@ -1,0 +1,17 @@
+package com.hostiflix.service
+
+import com.hostiflix.entity.Job
+import com.hostiflix.entity.JobStatus
+import com.hostiflix.repository.JobRepository
+import org.springframework.stereotype.Service
+
+@Service
+class JobService (
+    private val jobRepository: JobRepository
+) {
+    fun updateJobStatusById(id: String, status: JobStatus): Job? {
+        val job = jobRepository.findById(id).takeIf { it.isPresent }?.get() ?: return null
+        job.status = status
+        return jobRepository.save(job)
+    }
+}

--- a/src/test/kotlin/com/hostiflix/controller/JobControllerTest.kt
+++ b/src/test/kotlin/com/hostiflix/controller/JobControllerTest.kt
@@ -1,0 +1,72 @@
+package com.hostiflix.controller
+
+import com.hostiflix.entity.JobStatus
+import com.hostiflix.service.JobService
+import com.hostiflix.support.MockData
+import com.nhaarman.mockito_kotlin.given
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+
+@RunWith(SpringJUnit4ClassRunner::class)
+@ContextConfiguration(classes = [JacksonAutoConfiguration::class])
+@WebMvcTest
+class JobControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Mock
+    private lateinit var jobService: JobService
+
+    @InjectMocks
+    private lateinit var jobController: JobController
+
+    @Before
+    fun init() {
+        mockMvc = MockMvcBuilders
+            .standaloneSetup(jobController)
+            .build()
+    }
+
+    @Test
+    fun `should return 404 when updating job status for invalid job id`() {
+        // given
+        val id = "invalid-id"
+        val newJobStatus = JobStatus.DEPLOYMENT_SUCCESSFUL
+        given(jobService.updateJobStatusById(id, newJobStatus)).willReturn(null)
+
+        // when, then
+        mockMvc
+            .perform(MockMvcRequestBuilders.put("/jobs/$id/status/${newJobStatus.toString()}"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
+    }
+
+    @Test
+    fun `should return no content when updating job status went successful`() {
+        // given
+        val id = "1234"
+        val newJobStatus = JobStatus.DEPLOYMENT_SUCCESSFUL
+        val job = MockData.job("j1", MockData.branch("b1", MockData.project("p1", "c1")))
+        given(jobService.updateJobStatusById(id, newJobStatus)).willReturn(job)
+
+        // when, then
+        mockMvc
+            .perform(MockMvcRequestBuilders.put("/jobs/$id/status/${newJobStatus.toString()}"))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isNoContent)
+    }
+}

--- a/src/test/kotlin/com/hostiflix/integrationTests/BaseIntegrationTest.kt
+++ b/src/test/kotlin/com/hostiflix/integrationTests/BaseIntegrationTest.kt
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.hostiflix.entity.AuthCredentials
 import com.hostiflix.entity.Customer
 import com.hostiflix.entity.Project
-import com.hostiflix.repository.AuthCredentialsRepository
-import com.hostiflix.repository.CustomerRepository
-import com.hostiflix.repository.GithubLoginStateRepository
-import com.hostiflix.repository.ProjectRepository
+import com.hostiflix.repository.*
 import com.hostiflix.support.MockData
 import io.restassured.RestAssured
 import org.junit.After
@@ -59,6 +56,9 @@ abstract class BaseIntegrationTest {
 
     @Autowired
     lateinit var projectRepository: ProjectRepository
+
+    @Autowired
+    lateinit var jobRepository: JobRepository
 
     @Autowired
     lateinit var githubLoginStateRepository: GithubLoginStateRepository

--- a/src/test/kotlin/com/hostiflix/integrationTests/JobIntegrationTest.kt
+++ b/src/test/kotlin/com/hostiflix/integrationTests/JobIntegrationTest.kt
@@ -1,0 +1,52 @@
+package com.hostiflix.integrationTests
+
+import com.hostiflix.entity.JobStatus
+import com.hostiflix.support.MockData
+import io.restassured.RestAssured
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.springframework.http.HttpStatus
+
+class JobIntegrationTest: BaseIntegrationTest() {
+
+    @Before
+    fun setUp() {
+        RestAssured.basePath = "/jobs"
+    }
+
+    @Test
+    fun `should update job status`() {
+        // given
+        var project = MockData.project("p1", testCustomer!!.id!!)
+        project = projectRepository.save(project)
+        var job = project.branches.first().jobs.first()
+        job.status = JobStatus.BUILD_SCHEDULED
+        job = jobRepository.save(job)
+        val newStatus = JobStatus.DEPLOYMENT_SUCCESSFUL
+
+        // when, then
+        RestAssured
+            .given()
+            .header("Access-Token", accessToken)
+            .put("/${job.id}/status/${newStatus.toString()}")
+            .then()
+            .log().ifValidationFails()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+
+        val resultingJob = jobRepository.findById(job.id!!).get()
+        assertThat(resultingJob.status).isEqualTo(JobStatus.DEPLOYMENT_SUCCESSFUL)
+    }
+
+    @Test
+    fun `should return 404 when updating status of non existing job`() {
+        // given, when, then
+        RestAssured
+            .given()
+            .header("Access-Token", accessToken)
+            .put("/invalid-id/status/DEPLOYMENT_SUCCESSFUL")
+            .then()
+            .log().ifValidationFails()
+            .statusCode(HttpStatus.NOT_FOUND.value())
+    }
+}

--- a/src/test/kotlin/com/hostiflix/service/JobServiceTest.kt
+++ b/src/test/kotlin/com/hostiflix/service/JobServiceTest.kt
@@ -1,0 +1,54 @@
+package com.hostiflix.service
+
+import com.hostiflix.entity.JobStatus
+import com.hostiflix.repository.JobRepository
+import com.hostiflix.support.MockData
+import com.nhaarman.mockito_kotlin.given
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import java.util.*
+
+@RunWith(MockitoJUnitRunner::class)
+class JobServiceTest {
+
+    @Mock
+    private lateinit var jobRepository: JobRepository
+
+    @InjectMocks
+    private lateinit var jobService: JobService
+
+    @Test
+    fun `should return null if job id is not existing`() {
+        // given
+        val id = "invalid-id"
+        given(jobRepository.findById(id)).willReturn(Optional.empty())
+
+        // when
+        val result = jobService.updateJobStatusById(id, JobStatus.BUILD_FAILED)
+
+        // then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `should return job after job was update successfully`() {
+        // given
+        val id = "1234"
+        val newStatus = JobStatus.DEPLOYMENT_SUCCESSFUL
+        val job = MockData.job("j1", MockData.branch("b1", MockData.project("p1", "c1")))
+
+        given(jobRepository.findById(id)).willReturn(Optional.of(job))
+        given(jobRepository.save(job)).willReturn(job)
+
+        // when
+        val result = jobService.updateJobStatusById(id, newStatus)
+
+        // then
+        assertThat(result).isNotNull
+        assertThat(result!!.status).isEqualTo(newStatus)
+    }
+}


### PR DESCRIPTION
# What?

endpoint to update job status by job id

# Why?

The `deployment-service` will call this endpoint several times during building and deploying the users application.

# How?

For now this endpoint is open to everybody with a valid access-token. That has to be changed, so that only our `deployment-service` has access. I would skip this part for now, so that we achieve our working MVP quickly.