### PR TITLE
Feat development redirect url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,12 +83,12 @@ workflows:
       - push_to_gcr:
           requires:
             - build
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master
       - deploy_to_k8s:
           requires:
             - push_to_gcr
-#          filters:
-#            branches:
-#              only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,12 +83,12 @@ workflows:
       - push_to_gcr:
           requires:
             - build
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master
       - deploy_to_k8s:
           requires:
             - push_to_gcr
-          filters:
-            branches:
-              only: master
+#          filters:
+#            branches:
+#              only: master

--- a/src/main/kotlin/com/hostiflix/config/GithubConfig.kt
+++ b/src/main/kotlin/com/hostiflix/config/GithubConfig.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration
 @ConfigurationProperties("github")
 class GithubConfig {
     lateinit var loginBase : String
-    lateinit var loginRedirect : String
+    lateinit var loginAuthorize : String
     lateinit var loginGetAccessToken : String
     lateinit var apiBase : String
     lateinit var apiUser : String

--- a/src/main/kotlin/com/hostiflix/controller/AuthenticationController.kt
+++ b/src/main/kotlin/com/hostiflix/controller/AuthenticationController.kt
@@ -6,17 +6,29 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.view.RedirectView
 
 @RestController
 @RequestMapping("/auth")
 class AuthenticationController (
     private val authenticationService: AuthenticationService
-){
-    @GetMapping("/login")
-    fun buildNewRedirectUrlForGithub(): ResponseEntity<*> {
-        val githubRedirectUrl = authenticationService.buildNewRedirectUrlForGithub()
+) {
 
-        return ResponseEntity.ok().body(hashMapOf("redirectUrlGithub" to githubRedirectUrl))
+    @GetMapping("/login")
+    fun getGithubAuthorizeUrl(): ResponseEntity<*> {
+        val githubAuthorizeUrl = authenticationService.buildGithubAuthorizeUrl()
+
+        return ResponseEntity.ok().body(hashMapOf("githubAuthorizeUrl" to githubAuthorizeUrl))
+    }
+
+    @GetMapping("/getRedirectUrl")
+    fun getRedirectUrl(
+        @RequestParam
+        code: String,
+        @RequestParam
+        state: String
+    ): RedirectView {
+        return RedirectView(authenticationService.buildRedirectUrl(code, state))
     }
 
     @GetMapping("/getAccessToken")

--- a/src/main/kotlin/com/hostiflix/controller/AuthenticationController.kt
+++ b/src/main/kotlin/com/hostiflix/controller/AuthenticationController.kt
@@ -1,11 +1,9 @@
 package com.hostiflix.controller
 
+import com.hostiflix.dto.GithubRedirectEnvironment
 import com.hostiflix.service.AuthenticationService
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.view.RedirectView
 
 @RestController
@@ -15,20 +13,25 @@ class AuthenticationController (
 ) {
 
     @GetMapping("/login")
-    fun getGithubAuthorizeUrl(): ResponseEntity<*> {
-        val githubAuthorizeUrl = authenticationService.buildGithubAuthorizeUrl()
+    fun getGithubAuthorizeUrl(
+        @RequestParam
+        environment: GithubRedirectEnvironment?
+    ): ResponseEntity<*> {
+        val githubAuthorizeUrl = authenticationService.buildGithubAuthorizeUrl(environment ?: GithubRedirectEnvironment.PRODUCTION)
 
         return ResponseEntity.ok().body(hashMapOf("githubAuthorizeUrl" to githubAuthorizeUrl))
     }
 
-    @GetMapping("/getRedirectUrl")
+    @GetMapping("/getRedirectUrl/{environment}")
     fun getRedirectUrl(
         @RequestParam
         code: String,
         @RequestParam
-        state: String
+        state: String,
+        @PathVariable("environment")
+        environment: GithubRedirectEnvironment
     ): RedirectView {
-        return RedirectView(authenticationService.buildRedirectUrl(code, state))
+        return RedirectView(authenticationService.buildRedirectUrl(code, state, environment))
     }
 
     @GetMapping("/getAccessToken")

--- a/src/main/kotlin/com/hostiflix/dto/GithubRedirectEnvironment.kt
+++ b/src/main/kotlin/com/hostiflix/dto/GithubRedirectEnvironment.kt
@@ -1,0 +1,8 @@
+package com.hostiflix.dto
+
+enum class GithubRedirectEnvironment {
+
+    PRODUCTION,
+
+    DEVELOPMENT
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,12 +1,13 @@
 noAccessTokenRequiredEndpoints: /auth, /github/webhook
 
-defaultRedirectUrl: http://localhost:3000/github-redirect
+hostiflix-login-redirect: https://hostiflix.com/github-redirect
 
 deploymentServiceUrl: http://deployment-service/jobs/submit
 
 github:
   login-base: https://github.com/login/oauth/
-  login-redirect: authorize?client_id=${GITHUB_CLIENT_ID}&redirect_uri=${defaultRedirectUrl}&state={state}&scope={scope}
+  login-redirect: https://api.hostiflix.com/auth/getRedirectUrl
+  login-authorize: authorize?client_id=${GITHUB_CLIENT_ID}&redirect_uri=${github.login-redirect}&state={state}&scope={scope}
   login-get-access-token: access_token?client_id=${GITHUB_CLIENT_ID}&client_secret=${GITHUB_CLIENT_SECRET}&code={code}&redirect_uri=${defaultRedirectUrl}&state={state}
   api-base: https://api.github.com/
   api-user: user

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,14 +1,16 @@
 noAccessTokenRequiredEndpoints: /auth, /github/webhook
 
-hostiflix-login-redirect: https://hostiflix.com/github-redirect
+hostiflix-login-redirect:
+  prod: https://hostiflix.com/github-redirect
+  dev: http://localhost:3000/github-redirect
 
 deploymentServiceUrl: http://deployment-service/jobs/submit
 
 github:
   login-base: https://github.com/login/oauth/
-  login-redirect: https://api.hostiflix.com/auth/getRedirectUrl
+  login-redirect: https://api.hostiflix.com/auth/getRedirectUrl/{environment}
   login-authorize: authorize?client_id=${GITHUB_CLIENT_ID}&redirect_uri=${github.login-redirect}&state={state}&scope={scope}
-  login-get-access-token: access_token?client_id=${GITHUB_CLIENT_ID}&client_secret=${GITHUB_CLIENT_SECRET}&code={code}&redirect_uri=${defaultRedirectUrl}&state={state}
+  login-get-access-token: access_token?client_id=${GITHUB_CLIENT_ID}&client_secret=${GITHUB_CLIENT_SECRET}&code={code}&state={state}
   api-base: https://api.github.com/
   api-user: user
   api-emails: user/emails

--- a/src/test/kotlin/com/hostiflix/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/hostiflix/controller/AuthenticationControllerTest.kt
@@ -57,7 +57,7 @@ class AuthenticationControllerTest {
             .perform(get("/auth/login"))
             .andDo(print())
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.redirectUrlGithub", `is` (githubRedirectUrl)))
+            .andExpect(jsonPath("$.githubAuthorizeUrl", `is` (githubRedirectUrl)))
     }
 
     @Test

--- a/src/test/kotlin/com/hostiflix/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/hostiflix/controller/AuthenticationControllerTest.kt
@@ -50,7 +50,7 @@ class AuthenticationControllerTest {
     fun `should return new redirect url for github`() {
         /* Given */
         val githubRedirectUrl = "githubRedirectUrl"
-        given(authenticationService.buildNewRedirectUrlForGithub()).willReturn(githubRedirectUrl)
+        given(authenticationService.buildGithubAuthorizeUrl()).willReturn(githubRedirectUrl)
 
         /* When, Then */
         mockMvc

--- a/src/test/kotlin/com/hostiflix/controller/AuthenticationControllerTest.kt
+++ b/src/test/kotlin/com/hostiflix/controller/AuthenticationControllerTest.kt
@@ -1,5 +1,6 @@
 package com.hostiflix.controller
 
+import com.hostiflix.dto.GithubRedirectEnvironment
 import com.hostiflix.config.JsonConfig
 import com.hostiflix.service.AuthenticationService
 import com.nhaarman.mockito_kotlin.given
@@ -49,8 +50,8 @@ class AuthenticationControllerTest {
     @Test
     fun `should return new redirect url for github`() {
         /* Given */
-        val githubRedirectUrl = "githubRedirectUrl"
-        given(authenticationService.buildGithubAuthorizeUrl()).willReturn(githubRedirectUrl)
+        val githubRedirectUrl = "githubRedirectUrl/PRODUCTION"
+        given(authenticationService.buildGithubAuthorizeUrl(GithubRedirectEnvironment.PRODUCTION)).willReturn(githubRedirectUrl)
 
         /* When, Then */
         mockMvc

--- a/src/test/kotlin/com/hostiflix/integrationTests/AuthenticationIntegrationTest.kt
+++ b/src/test/kotlin/com/hostiflix/integrationTests/AuthenticationIntegrationTest.kt
@@ -25,7 +25,7 @@ class AuthenticationIntegrationTest: BaseIntegrationTest() {
             .then()
             .log().ifValidationFails()
             .statusCode(HttpStatus.OK.value())
-            .body("redirectUrlGithub", notNullValue())
+            .body("githubAuthorizeUrl", notNullValue())
 
         val githubLoginStateList = githubLoginStateRepository.findAll().toList()
         assertThat(githubLoginStateList.size).isEqualTo(1)

--- a/src/test/kotlin/com/hostiflix/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/hostiflix/service/AuthenticationServiceTest.kt
@@ -1,6 +1,7 @@
 package com.hostiflix.service
 
 import com.hostiflix.config.GithubConfig
+import com.hostiflix.dto.GithubRedirectEnvironment
 import com.hostiflix.entity.AuthCredentials
 import com.hostiflix.entity.GithubLoginState
 import com.hostiflix.repository.AuthCredentialsRepository
@@ -43,7 +44,7 @@ class AuthenticationServiceTest {
     @Before
     fun setup() {
         given(githubConfig.loginBase).willReturn("http://github.com/")
-        given(githubConfig.loginAuthorize).willReturn("redirect?state={state}&scope={scope}")
+        given(githubConfig.loginAuthorize).willReturn("redirect/{environment}?state={state}&scope={scope}")
     }
 
     @Test
@@ -53,10 +54,10 @@ class AuthenticationServiceTest {
         given(githubLoginStateRepository.save<GithubLoginState>(any())).willReturn(GithubLoginState(stateId))
 
         /* When */
-        val githubRedirectUrl = authenticationService.buildGithubAuthorizeUrl()
+        val githubRedirectUrl = authenticationService.buildGithubAuthorizeUrl(GithubRedirectEnvironment.PRODUCTION)
 
         /* Then */
-        assertThat(githubRedirectUrl).isEqualTo("http://github.com/redirect?state=id&scope=REPO,USER")
+        assertThat(githubRedirectUrl).isEqualTo("http://github.com/redirect/PRODUCTION?state=id&scope=REPO,USER")
     }
 
     @Test

--- a/src/test/kotlin/com/hostiflix/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/hostiflix/service/AuthenticationServiceTest.kt
@@ -53,7 +53,7 @@ class AuthenticationServiceTest {
         given(githubLoginStateRepository.save<GithubLoginState>(any())).willReturn(GithubLoginState(stateId))
 
         /* When */
-        val githubRedirectUrl = authenticationService.buildNewRedirectUrlForGithub()
+        val githubRedirectUrl = authenticationService.buildGithubAuthorizeUrl()
 
         /* Then */
         assertThat(githubRedirectUrl).isEqualTo("http://github.com/redirect?state=id&scope=REPO,USER")

--- a/src/test/kotlin/com/hostiflix/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/hostiflix/service/AuthenticationServiceTest.kt
@@ -43,7 +43,7 @@ class AuthenticationServiceTest {
     @Before
     fun setup() {
         given(githubConfig.loginBase).willReturn("http://github.com/")
-        given(githubConfig.loginRedirect).willReturn("redirect?state={state}&scope={scope}")
+        given(githubConfig.loginAuthorize).willReturn("redirect?state={state}&scope={scope}")
     }
 
     @Test


### PR DESCRIPTION
# What?

Change github redirect url to `/auth/getRedirectUrl/{environment}`, so that we can use different redirect urls for different environments

# Why?

When running the webapp locally for development we have to use `http://localhost:3000` as redirect url, whereas in production we use `https://hostiflix.com`.
