### PR TITLE
Create projects only with unused hashes

### DIFF
--- a/src/main/kotlin/com/hostiflix/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/hostiflix/repository/ProjectRepository.kt
@@ -1,6 +1,7 @@
 package com.hostiflix.repository
 
 import com.hostiflix.entity.Project
+import com.hostiflix.entity.ProjectHash
 import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
@@ -12,6 +13,8 @@ interface ProjectRepository : CrudRepository<Project, String> {
     fun findByIdAndCustomerId(id: String, customerId: String): Project?
 
     fun existsByIdAndCustomerId(id: String, customerId: String): Boolean
+
+    fun existsByProjectHash(projectHash: ProjectHash): Boolean
 
     fun findByRepositoryOwnerAndRepositoryName(repositoryOwner: String, repositoryName: String) : Project?
 }

--- a/src/main/kotlin/com/hostiflix/service/ProjectService.kt
+++ b/src/main/kotlin/com/hostiflix/service/ProjectService.kt
@@ -38,7 +38,9 @@ class ProjectService (
     @Transactional
     fun createProject(newProject: Project, accessToken: String) : Project {
         val projectHash = newProject.assignHash?.let { hash ->
-            projectHashRepository.findById(hash).takeIf { it.isPresent }?.get()
+            projectHashRepository.findById(hash).takeIf {
+                it.isPresent && !projectRepository.existsByProjectHash(it.get())
+            }?.get()
         } ?: throw BadRequestException("project hash is missing or invalid")
 
         newProject.projectHash = projectHash

--- a/src/main/kotlin/com/hostiflix/support/UnprocessableEntityException.kt
+++ b/src/main/kotlin/com/hostiflix/support/UnprocessableEntityException.kt
@@ -1,0 +1,7 @@
+package com.hostiflix.support
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+class UnprocessableEntityException (exception: String): IllegalArgumentException(exception)

--- a/src/main/kotlin/com/hostiflix/webservice/githubWs/GithubWsImpl.kt
+++ b/src/main/kotlin/com/hostiflix/webservice/githubWs/GithubWsImpl.kt
@@ -3,6 +3,8 @@ package com.hostiflix.webservice.githubWs
 import com.hostiflix.config.GithubConfig
 import com.hostiflix.dto.*
 import com.hostiflix.entity.Project
+import com.hostiflix.support.BadRequestException
+import com.hostiflix.support.UnprocessableEntityException
 import org.springframework.context.annotation.Profile
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpEntity
@@ -79,9 +81,12 @@ class GithubWsImpl(
                 project.repositoryName
             )
         } catch (e: HttpStatusCodeException) {
+            val errorMessage = "Github webhook creation failed with status code ${e.statusCode}, body: ${e.responseBodyAsString}"
             when (e.statusCode) {
                 HttpStatus.OK -> return
-                else -> throw IllegalArgumentException("creating Github webhook failed with status code ${e.statusCode}, body: ${e.responseBodyAsString}")
+                HttpStatus.UNPROCESSABLE_ENTITY -> throw UnprocessableEntityException(errorMessage)
+                HttpStatus.BAD_REQUEST -> throw BadRequestException(errorMessage)
+                else -> throw IllegalArgumentException(errorMessage)
             }
         }
     }

--- a/src/test/kotlin/com/hostiflix/integrationTests/ProjectIntegrationTest.kt
+++ b/src/test/kotlin/com/hostiflix/integrationTests/ProjectIntegrationTest.kt
@@ -151,6 +151,29 @@ class ProjectIntegrationTest: BaseIntegrationTest() {
     }
 
     @Test
+    fun `should not create project if project hash is already in use`() {
+        val projectHash = "ph1"
+        val existingProject = MockData.project("1", testCustomer!!.id!!, projectHash)
+        projectRepository.save(existingProject)
+
+        val newProject = MockData.project("3", testCustomer!!.id!!, projectHash)
+        val body = objectMapper.writeValueAsString(newProject)
+
+        RestAssured
+            .given()
+            .header("Access-Token", accessToken)
+            .contentType(ContentType.JSON)
+            .body(body)
+            .post()
+            .then()
+            .log().ifValidationFails()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+
+        val projectList = projectRepository.findAll().toList()
+        assertThat(projectList.size).isEqualTo(1)
+    }
+
+    @Test
     fun `should update project without touching jobs and project hash`() {
         val mockProject = MockData.project("4", testCustomer!!.id!!)
         val project = projectRepository.save(mockProject)

--- a/src/test/kotlin/com/hostiflix/service/ProjectServiceTest.kt
+++ b/src/test/kotlin/com/hostiflix/service/ProjectServiceTest.kt
@@ -102,6 +102,7 @@ class ProjectServiceTest {
         newProject.projectHash = null
 
         given(projectHashRepository.findById(projectHashId)).willReturn(Optional.of(projectHash))
+        given(projectRepository.existsByProjectHash(projectHash)).willReturn(false)
         given(authenticationService.getCustomerIdByAccessToken(accessToken)).willReturn(customerId)
         given(projectRepository.save<Project>(check {
             assertThat(it.id).isEqualTo(newProject.id)
@@ -126,6 +127,24 @@ class ProjectServiceTest {
         newProject.projectHash = null
 
         // when, then
+        projectService.createProject(newProject, accessToken)
+    }
+
+    @Test(expected = BadRequestException::class)
+    fun `should throw exception if project hash already in use`() {
+        // given
+        val accessToken = "accessToken"
+        val customerId = "c1"
+        val projectHashId = "ph1"
+        val projectHash = ProjectHash(projectHashId)
+        val newProject = MockData.project("p1", customerId, projectHashId)
+        newProject.hash = projectHashId
+        newProject.projectHash = null
+
+        given(projectHashRepository.findById(projectHashId)).willReturn(Optional.of(projectHash))
+        given(projectRepository.existsByProjectHash(projectHash)).willReturn(true)
+
+        // when
         projectService.createProject(newProject, accessToken)
     }
 


### PR DESCRIPTION
# What?

- create project only if projectHash is unused
- create github webhook error handling

# Why?

- project hash should be a unique id per project