### PR TITLE
Fixed that all 'latest' of authCredentials are set to false only from…

### DIFF
--- a/src/main/kotlin/com/hostiflix/controller/JobController.kt
+++ b/src/main/kotlin/com/hostiflix/controller/JobController.kt
@@ -24,6 +24,6 @@ class JobController (
         if (jobService.updateJobStatusById(id, status) == null) {
             return ResponseEntity.notFound().build<Any>()
         }
-        return ResponseEntity.noContent().build<Any>();
+        return ResponseEntity.noContent().build<Any>()
     }
 }

--- a/src/main/kotlin/com/hostiflix/entity/AuthCredentials.kt
+++ b/src/main/kotlin/com/hostiflix/entity/AuthCredentials.kt
@@ -6,7 +6,7 @@ import javax.persistence.GeneratedValue
 import javax.persistence.Id
 
 @Entity
-class AuthCredentials(
+data class AuthCredentials(
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid2")

--- a/src/main/kotlin/com/hostiflix/entity/Customer.kt
+++ b/src/main/kotlin/com/hostiflix/entity/Customer.kt
@@ -5,7 +5,7 @@ import org.hibernate.annotations.GenericGenerator
 import javax.persistence.*
 
 @Entity
-class Customer(
+data class Customer(
     @Id
     @GeneratedValue(generator = "system-uuid")
     @GenericGenerator(name = "system-uuid", strategy = "uuid2")
@@ -13,12 +13,13 @@ class Customer(
 	var name: String,
 	var email: String,
 	var githubUsername: String,
-	val githubId: String,
+	val githubId: String
+) {
 	@JsonIgnore
 	@OneToMany(
-		fetch = FetchType.LAZY,
-		mappedBy = "customerId",
-		cascade = [CascadeType.ALL]
+			fetch = FetchType.LAZY,
+			mappedBy = "customerId",
+			cascade = [CascadeType.ALL]
 	)
 	val authCredentials: List<AuthCredentials> = emptyList()
-)
+}

--- a/src/main/kotlin/com/hostiflix/repository/AuthCredentialsRepository.kt
+++ b/src/main/kotlin/com/hostiflix/repository/AuthCredentialsRepository.kt
@@ -15,4 +15,7 @@ interface AuthCredentialsRepository : CrudRepository<AuthCredentials, String> {
 
     // SELECT * FROM auth_credentials WHERE github_access_token=githubAccessToken;
     fun findByGithubAccessToken(githubAccessToken : String) : AuthCredentials?
+
+    // SELECT * FROM auth_credentials WHERE customer_id=customerId;
+    fun findAllByCustomerId(customerId: String) : List<AuthCredentials>
 }

--- a/src/main/kotlin/com/hostiflix/repository/ProjectRepository.kt
+++ b/src/main/kotlin/com/hostiflix/repository/ProjectRepository.kt
@@ -8,10 +8,10 @@ import org.springframework.stereotype.Repository
 @Repository
 interface ProjectRepository : CrudRepository<Project, String> {
 
-    // SELECT * FROM project WHERE customer_id=customerI;
-    fun findAllByCustomerId(customerId: String): List<Project>
+    // SELECT * FROM project WHERE customer_id=customerId ORDER BY name;
+    fun findAllByCustomerIdOrderByName(customerId: String): List<Project>
 
-    // SELECT * FROM project WHERE id=id AND customer_i =customerId;
+    // SELECT * FROM project WHERE id=id AND customer_id = customerId;
     fun findByIdAndCustomerId(id: String, customerId: String): Project?
 
     // SELECT CASE WHEN EXISTS ( SELECT * FROM project WHERE id=id AND customer_id=customerID) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)END;

--- a/src/main/kotlin/com/hostiflix/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/hostiflix/service/AuthenticationService.kt
@@ -75,8 +75,9 @@ class AuthenticationService (
             createAndStoreNewCustomer(githubCustomer, githubCustomerPrimaryEmail)
         }
 
-        setAllExistingAccessTokensToLatestFalse()
-        createAndStoreNewAuthCredentials(githubCustomer.id, accessToken)
+        val customer = customerService.findCustomerByGithubId(githubCustomer.id)
+        setAllExistingAccessTokensToLatestFalse(customer.id!!)
+        createAndStoreNewAuthCredentials(customer.id!!, accessToken)
 
         return accessToken
     }
@@ -87,10 +88,9 @@ class AuthenticationService (
         customerService.createCustomer(newCustomer)
     }
 
-    // SELECT * FROM auth_credentials;
     // UPDATE auth_credentials SET latest=it.latest WHERE id=it.id
-    fun setAllExistingAccessTokensToLatestFalse() {
-        val listOfAuthCredentials = authCredentialsRepository.findAll()
+    fun setAllExistingAccessTokensToLatestFalse(customerId: String) {
+        val listOfAuthCredentials = authCredentialsRepository.findAllByCustomerId(customerId)
         listOfAuthCredentials.forEach {
             it.latest = false
             authCredentialsRepository.save(it)
@@ -98,9 +98,8 @@ class AuthenticationService (
     }
 
     // INSERT INTO auth_credentials VALUES (newAuthCredentials.id, newAuthCredentials.githubAccessToken, newAuthCredentials.customerId, newAuthCredentials.latest);
-    fun createAndStoreNewAuthCredentials(githubId: String, accessToken: String?) {
-        val customer = customerService.findCustomerByGithubId(githubId)
-        val newAuthCredentials = AuthCredentials(null, accessToken!!, customer.id!!,  true)
+    fun createAndStoreNewAuthCredentials(customerId: String, accessToken: String?) {
+        val newAuthCredentials = AuthCredentials(null, accessToken!!, customerId,  true)
 
         authCredentialsRepository.save(newAuthCredentials)
     }

--- a/src/main/kotlin/com/hostiflix/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/hostiflix/service/AuthenticationService.kt
@@ -98,8 +98,8 @@ class AuthenticationService (
     }
 
     // INSERT INTO auth_credentials VALUES (newAuthCredentials.id, newAuthCredentials.githubAccessToken, newAuthCredentials.customerId, newAuthCredentials.latest);
-    fun createAndStoreNewAuthCredentials(customerId: String, accessToken: String?) {
-        val newAuthCredentials = AuthCredentials(null, accessToken!!, customerId,  true)
+    fun createAndStoreNewAuthCredentials(customerId: String, accessToken: String) {
+        val newAuthCredentials = AuthCredentials(null, accessToken, customerId,  true)
 
         authCredentialsRepository.save(newAuthCredentials)
     }

--- a/src/main/kotlin/com/hostiflix/service/ProjectService.kt
+++ b/src/main/kotlin/com/hostiflix/service/ProjectService.kt
@@ -19,7 +19,7 @@ class ProjectService (
 ) {
 
     fun findAllProjectsByAccessToken(accessToken: String): List<Project> {
-        return projectRepository.findAllByCustomerId(getCustomerId(accessToken)).toList()
+        return projectRepository.findAllByCustomerIdOrderByName(getCustomerId(accessToken)).toList()
     }
 
     fun findProjectByIdAndAccessToken(id: String, accessToken: String): Project? {
@@ -36,7 +36,7 @@ class ProjectService (
         return projectRepository.save(project)
     }
 
-    // SELECT * project_hash WHERE id=hash;
+    // SELECT * FROM project_hash WHERE id=hash;
     @Transactional
     fun createProject(newProject: Project, accessToken: String) : Project {
         val projectHash = newProject.assignHash?.let { hash ->

--- a/src/main/kotlin/com/hostiflix/webservice/githubWs/GithubWsImpl.kt
+++ b/src/main/kotlin/com/hostiflix/webservice/githubWs/GithubWsImpl.kt
@@ -83,7 +83,6 @@ class GithubWsImpl(
         } catch (e: HttpStatusCodeException) {
             val errorMessage = "Github webhook creation failed with status code ${e.statusCode}, body: ${e.responseBodyAsString}"
             when (e.statusCode) {
-                HttpStatus.OK -> return
                 HttpStatus.UNPROCESSABLE_ENTITY -> throw UnprocessableEntityException(errorMessage)
                 HttpStatus.BAD_REQUEST -> throw BadRequestException(errorMessage)
                 else -> throw IllegalArgumentException(errorMessage)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,11 @@ spring:
     username: "postgres"
     password: "password"
     driver-class-name: org.postgresql.Driver
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
 
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults: false
 spring.jpa.database-platform: org.hibernate.dialect.PostgreSQL9Dialect

--- a/src/test/kotlin/com/hostiflix/controller/CustomerControllerTest.kt
+++ b/src/test/kotlin/com/hostiflix/controller/CustomerControllerTest.kt
@@ -16,7 +16,6 @@ import org.mockito.Mock
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 import org.springframework.test.web.servlet.MockMvc
@@ -35,9 +34,6 @@ class CustomerControllerTest {
     private lateinit var mockMvc: MockMvc
 
     @Autowired
-    private lateinit var jackson2HttpMessageConverter: MappingJackson2HttpMessageConverter
-
-    @Autowired
     lateinit var objectMapper: ObjectMapper
 
     @Mock
@@ -50,7 +46,6 @@ class CustomerControllerTest {
     fun init() {
         mockMvc = MockMvcBuilders
             .standaloneSetup(customerController)
-            .setMessageConverters(this.jackson2HttpMessageConverter)
             .build()
     }
 

--- a/src/test/kotlin/com/hostiflix/integrationTests/BaseIntegrationTest.kt
+++ b/src/test/kotlin/com/hostiflix/integrationTests/BaseIntegrationTest.kt
@@ -20,30 +20,8 @@ import org.springframework.test.context.junit4.SpringRunner
 @RunWith(SpringRunner::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
-//@ContextConfiguration(initializers = [BaseIntegrationTest.Initializer::class])
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 abstract class BaseIntegrationTest {
-
-//    TODO: make testcontainers work in CircleCI
-//    companion object {
-//        @ClassRule
-//        @JvmField
-//        var postgreSQLContainer: PostgreSQLContainer<*> = KPostgreSQLContainer()
-//            .withPassword("password")
-//            .withUsername("postgres")
-//    }
-//
-//    object Initializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
-//        override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
-//            val jdbcUrl = postgreSQLContainer.getJdbcUrl()
-//            val values = TestPropertyValues.of(
-//                    "spring.datasource.url=$jdbcUrl",
-//                    "spring.datasource.password=" + BaseIntegrationTest.postgreSQLContainer.getPassword(),
-//                    "spring.datasource.username=" + BaseIntegrationTest.postgreSQLContainer.getUsername()
-//            )
-//            values.applyTo(configurableApplicationContext)
-//        }
-//    }
 
     @Value("\${local.server.port}")
     val serverPort: Int = 0

--- a/src/test/kotlin/com/hostiflix/integrationTests/CustomerIntegrationTest.kt
+++ b/src/test/kotlin/com/hostiflix/integrationTests/CustomerIntegrationTest.kt
@@ -7,7 +7,6 @@ import io.restassured.http.ContentType
 import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.`is`
 import org.hamcrest.Matchers.hasSize
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.springframework.http.HttpStatus

--- a/src/test/kotlin/com/hostiflix/service/CustomerServiceTest.kt
+++ b/src/test/kotlin/com/hostiflix/service/CustomerServiceTest.kt
@@ -8,10 +8,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
 import java.util.*
 
-@RunWith(MockitoJUnitRunner::class)
+@RunWith(SpringJUnit4ClassRunner::class)
 class CustomerServiceTest {
 
     @Mock


### PR DESCRIPTION
# What?
Fixed that only the authCredentials from the customer are set to 'latest' false.
# Why?
Until now, all authCredentials from all customers are set to 'latest' false. 
